### PR TITLE
Create intro page skeleton

### DIFF
--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,16 +12,49 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Arobotherapy" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4dD-S9-A8E">
+                                <rect key="frame" x="10" y="30" width="355" height="627"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qBt-Ou-abK">
+                                        <rect key="frame" x="0.0" y="0.0" width="355" height="467"/>
+                                    </imageView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M7V-Lc-pvU">
+                                        <rect key="frame" x="0.0" y="477" width="355" height="150"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="150" id="CXs-2j-hBs"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="M7V-Lc-pvU" secondAttribute="trailing" id="16V-AS-MIp"/>
+                                    <constraint firstAttribute="bottom" secondItem="M7V-Lc-pvU" secondAttribute="bottom" id="39e-NH-Eyg"/>
+                                    <constraint firstItem="qBt-Ou-abK" firstAttribute="leading" secondItem="4dD-S9-A8E" secondAttribute="leading" id="RFt-5o-eK3"/>
+                                    <constraint firstAttribute="trailing" secondItem="qBt-Ou-abK" secondAttribute="trailing" id="akO-qg-Ij5"/>
+                                    <constraint firstItem="M7V-Lc-pvU" firstAttribute="top" secondItem="qBt-Ou-abK" secondAttribute="bottom" constant="10" id="ar9-2F-g8w"/>
+                                    <constraint firstItem="M7V-Lc-pvU" firstAttribute="leading" secondItem="4dD-S9-A8E" secondAttribute="leading" id="dgu-H0-xKW"/>
+                                    <constraint firstItem="qBt-Ou-abK" firstAttribute="top" secondItem="4dD-S9-A8E" secondAttribute="top" id="hdC-3g-ChN"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="4dD-S9-A8E" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="1vz-t8-whf"/>
+                            <constraint firstItem="4dD-S9-A8E" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="2RN-MB-PGf"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="4dD-S9-A8E" secondAttribute="trailing" constant="10" id="fNR-UJ-njt"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="4dD-S9-A8E" secondAttribute="bottom" constant="10" id="r9Y-Xx-RDq"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-84" y="132.68365817091455"/>
         </scene>
     </scenes>
 </document>

--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -29,6 +29,9 @@
                                             <constraint firstAttribute="height" constant="150" id="CXs-2j-hBs"/>
                                         </constraints>
                                         <state key="normal" title="Button"/>
+                                        <connections>
+                                            <action selector="skipIntroView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7Mn-ht-bTN"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <constraints>

--- a/Arobotherapy/ViewController.swift
+++ b/Arobotherapy/ViewController.swift
@@ -10,11 +10,16 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    // MARK: Properties
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
     }
 
-
+    // MARK: Actions
+    @IBAction func skipIntroView(_ sender: UIButton) {
+        
+    }
 }
 


### PR DESCRIPTION
A button and an image, that's all there is folks! This commit sets up
that intro page according to the wireframes.  Eventually the image will
need to be created, though it won't be finalized until the rest of the
app is created (since it will need to reference visual components in the
instructions).

Seeing as how the only thing this view needs to do is let the user progress to the next page, there isn't much more to be done until the next page is... created!

This is the first step towards #1