### PR TITLE
Render dynamic passage

### DIFF
--- a/Arobotherapy.xcodeproj/project.pbxproj
+++ b/Arobotherapy.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D05C6E33216D2EFA002695F1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D05C6E32216D2EFA002695F1 /* Assets.xcassets */; };
 		D05C6E36216D2EFA002695F1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D05C6E34216D2EFA002695F1 /* LaunchScreen.storyboard */; };
 		D05C6E41216D2EFA002695F1 /* ArobotherapyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C6E40216D2EFA002695F1 /* ArobotherapyTests.swift */; };
+		D0A947272177C40400F7D4CC /* InterviewModelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A947262177C40400F7D4CC /* InterviewModelController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +53,7 @@
 		D05C6E3C216D2EFA002695F1 /* ArobotherapyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArobotherapyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D05C6E40216D2EFA002695F1 /* ArobotherapyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArobotherapyTests.swift; sourceTree = "<group>"; };
 		D05C6E42216D2EFA002695F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D0A947262177C40400F7D4CC /* InterviewModelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewModelController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 				D05C6E2D216D2EF8002695F1 /* IntroViewController.swift */,
 				D02C79EB216D52C800487826 /* PassageInstructionViewController.swift */,
 				D02C79ED216E547000487826 /* PassageRecordingViewController.swift */,
+				D0A947262177C40400F7D4CC /* InterviewModelController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -239,6 +242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D039FAE8216EF91100ADACA3 /* Passage.swift in Sources */,
+				D0A947272177C40400F7D4CC /* InterviewModelController.swift in Sources */,
 				D02C79EC216D52C800487826 /* PassageInstructionViewController.swift in Sources */,
 				D039FADB216E951F00ADACA3 /* InterviewInstructionViewController.swift in Sources */,
 				D039FAEA216EFB0000ADACA3 /* Question.swift in Sources */,

--- a/Arobotherapy.xcodeproj/project.pbxproj
+++ b/Arobotherapy.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D05C6E36216D2EFA002695F1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D05C6E34216D2EFA002695F1 /* LaunchScreen.storyboard */; };
 		D05C6E41216D2EFA002695F1 /* ArobotherapyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C6E40216D2EFA002695F1 /* ArobotherapyTests.swift */; };
 		D0A947272177C40400F7D4CC /* InterviewModelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A947262177C40400F7D4CC /* InterviewModelController.swift */; };
+		D0A9472A2177E4B400F7D4CC /* InterviewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A947292177E4B400F7D4CC /* InterviewProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,7 @@
 		D05C6E40216D2EFA002695F1 /* ArobotherapyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArobotherapyTests.swift; sourceTree = "<group>"; };
 		D05C6E42216D2EFA002695F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0A947262177C40400F7D4CC /* InterviewModelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewModelController.swift; sourceTree = "<group>"; };
+		D0A947292177E4B400F7D4CC /* InterviewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +120,7 @@
 		D05C6E2A216D2EF8002695F1 /* Arobotherapy */ = {
 			isa = PBXGroup;
 			children = (
+				D0A947282177DFF500F7D4CC /* Protocols */,
 				D039FAE4216EF8FA00ADACA3 /* Models */,
 				D039FAE0216EEC9200ADACA3 /* Library */,
 				D05C6E2B216D2EF8002695F1 /* AppDelegate.swift */,
@@ -137,6 +140,14 @@
 				D05C6E42216D2EFA002695F1 /* Info.plist */,
 			);
 			path = ArobotherapyTests;
+			sourceTree = "<group>";
+		};
+		D0A947282177DFF500F7D4CC /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				D0A947292177E4B400F7D4CC /* InterviewProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -243,6 +254,7 @@
 			files = (
 				D039FAE8216EF91100ADACA3 /* Passage.swift in Sources */,
 				D0A947272177C40400F7D4CC /* InterviewModelController.swift in Sources */,
+				D0A9472A2177E4B400F7D4CC /* InterviewProtocol.swift in Sources */,
 				D02C79EC216D52C800487826 /* PassageInstructionViewController.swift in Sources */,
 				D039FADB216E951F00ADACA3 /* InterviewInstructionViewController.swift in Sources */,
 				D039FAEA216EFB0000ADACA3 /* Question.swift in Sources */,

--- a/Arobotherapy/AppDelegate.swift
+++ b/Arobotherapy/AppDelegate.swift
@@ -17,6 +17,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         let interviewModelController = InterviewModelController()
         interviewModelController.loadData()
+        
+        if let introViewController = window?.rootViewController as? IntroViewController {
+            introViewController.interviewModelController = interviewModelController
+        }
         return true
     }
     

--- a/Arobotherapy/AppDelegate.swift
+++ b/Arobotherapy/AppDelegate.swift
@@ -12,50 +12,12 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var passages: [Passage] = []
-    var questions: [Question] = []
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        loadPassages()
-        loadQuestions()
-
+        let interviewModelController = InterviewModelController()
+        interviewModelController.loadData()
         return true
-    }
-    
-    func loadPassages() {
-        let fm = FileManager.default
-        let path = Bundle.main.resourcePath! + "/Library/Passages"
-        do {
-            let items = try fm.contentsOfDirectory(atPath: path)
-            
-            for item in items {
-                let filepath = Bundle.main.resourcePath! + "/Library/Passages/" + item
-                let contents = try String(contentsOfFile: filepath)
-                let passage = Passage(id: item, text: contents)
-                passages.append(passage)
-            }
-        } catch {
-            // failed to read directory – bad permissions, perhaps?
-        }
-    }
-    
-    func loadQuestions() {
-        let fm = FileManager.default
-        let path = Bundle.main.resourcePath! + "/Library/Questions/Text"
-        do {
-            let items = try fm.contentsOfDirectory(atPath: path)
-            
-            for item in items {
-                let filepath = Bundle.main.resourcePath! + "/Library/Questions/Text/" + item
-                let contents = try String(contentsOfFile: filepath)
-                let audioUrl = Bundle.main.resourcePath! + "/Library/Questions/Audio/" + item.replacingOccurrences(of: ".txt", with: ".mp3")
-                let question = Question(id: item, text: contents, audioUrl: audioUrl)
-                questions.append(question)
-            }
-        } catch {
-            // failed to read directory – bad permissions, perhaps?
-        }
     }
     
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -162,7 +162,7 @@
                         <viewLayoutGuide key="safeArea" id="qkg-uE-BIy"/>
                     </view>
                     <connections>
-                        <outlet property="passageTextView" destination="epl-7u-bb5" id="8VP-bL-4Rl"/>
+                        <outlet property="passageTextView" destination="epl-7u-bb5" id="tl0-Pl-dXZ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6Cc-eh-aiF" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Arobotherapy/Controllers/InterviewInstructionViewController.swift
+++ b/Arobotherapy/Controllers/InterviewInstructionViewController.swift
@@ -8,7 +8,10 @@
 
 import UIKit
 
-class InterviewInstructionViewController: UIViewController {
+class InterviewInstructionViewController: UIViewController, InterviewProtocol {
+
+    // MARK: Properties
+    var interviewModelController:InterviewModelController = InterviewModelController()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Arobotherapy/Controllers/InterviewInstructionViewController.swift
+++ b/Arobotherapy/Controllers/InterviewInstructionViewController.swift
@@ -19,15 +19,9 @@ class InterviewInstructionViewController: UIViewController, InterviewProtocol {
         // Do any additional setup after loading the view.
     }
     
-
-    /*
     // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
-}
+        if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
+            interviewProtocolViewController.interviewModelController = interviewModelController
+        }
+    }}

--- a/Arobotherapy/Controllers/InterviewModelController.swift
+++ b/Arobotherapy/Controllers/InterviewModelController.swift
@@ -1,0 +1,66 @@
+//
+//  ModelController.swift
+//  Arobotherapy
+//
+//  Created by Dan Schultz on 10/17/18.
+//  Copyright © 2018 Bad Idea Factory. All rights reserved.
+//
+
+import UIKit
+
+class InterviewModelController {
+    var passages: [Passage] = []
+    var questions: [Question] = []
+    
+    func generateScript() {
+        loadData()
+    }
+    
+    func loadData() {
+        loadPassages()
+        loadQuestions()
+    }
+    
+    func loadPassages() {
+        if(passages.count != 0) {
+            return
+        }
+
+        let fm = FileManager.default
+        let path = Bundle.main.resourcePath! + "/Library/Passages"
+        do {
+            let items = try fm.contentsOfDirectory(atPath: path)
+            
+            for item in items {
+                let filepath = Bundle.main.resourcePath! + "/Library/Passages/" + item
+                let contents = try String(contentsOfFile: filepath)
+                let passage = Passage(id: item, text: contents)
+                passages.append(passage)
+            }
+        } catch {
+            // failed to read directory – bad permissions, perhaps?
+        }
+    }
+    
+    func loadQuestions() {
+        if(questions.count != 0) {
+            return
+        }
+
+        let fm = FileManager.default
+        let path = Bundle.main.resourcePath! + "/Library/Questions/Text"
+        do {
+            let items = try fm.contentsOfDirectory(atPath: path)
+            
+            for item in items {
+                let filepath = Bundle.main.resourcePath! + "/Library/Questions/Text/" + item
+                let contents = try String(contentsOfFile: filepath)
+                let audioUrl = Bundle.main.resourcePath! + "/Library/Questions/Audio/" + item.replacingOccurrences(of: ".txt", with: ".mp3")
+                let question = Question(id: item, text: contents, audioUrl: audioUrl)
+                questions.append(question)
+            }
+        } catch {
+            // failed to read directory – bad permissions, perhaps?
+        }
+    }
+}

--- a/Arobotherapy/Controllers/InterviewModelController.swift
+++ b/Arobotherapy/Controllers/InterviewModelController.swift
@@ -12,8 +12,16 @@ class InterviewModelController {
     var passages: [Passage] = []
     var questions: [Question] = []
     
+    var chosenPassage:Passage?
+    var chosenQuestions: [Question] = []
+    
     func generateScript() {
         loadData()
+        
+        // Select exactly one passage
+        if(passages.count > 0) {
+            self.chosenPassage = passages.randomElement()!
+        }
     }
     
     func loadData() {
@@ -32,6 +40,9 @@ class InterviewModelController {
             let items = try fm.contentsOfDirectory(atPath: path)
             
             for item in items {
+                if(item.suffix(4) != ".txt") {
+                    continue
+                }
                 let filepath = Bundle.main.resourcePath! + "/Library/Passages/" + item
                 let contents = try String(contentsOfFile: filepath)
                 let passage = Passage(id: item, text: contents)
@@ -53,6 +64,9 @@ class InterviewModelController {
             let items = try fm.contentsOfDirectory(atPath: path)
             
             for item in items {
+                if(item.suffix(4) != ".txt") {
+                    continue
+                }
                 let filepath = Bundle.main.resourcePath! + "/Library/Questions/Text/" + item
                 let contents = try String(contentsOfFile: filepath)
                 let audioUrl = Bundle.main.resourcePath! + "/Library/Questions/Audio/" + item.replacingOccurrences(of: ".txt", with: ".mp3")

--- a/Arobotherapy/Controllers/InterviewViewController.swift
+++ b/Arobotherapy/Controllers/InterviewViewController.swift
@@ -8,23 +8,22 @@
 
 import UIKit
 
-class InterviewViewController: UIViewController {
+class InterviewViewController: UIViewController, InterviewProtocol {
 
+    // MARK: Properties
+    var interviewModelController:InterviewModelController = InterviewModelController()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
     }
     
-
-    /*
     // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
+            interviewProtocolViewController.interviewModelController = interviewModelController
+        }
     }
-    */
 
 }

--- a/Arobotherapy/Controllers/IntroViewController.swift
+++ b/Arobotherapy/Controllers/IntroViewController.swift
@@ -11,9 +11,12 @@ import UIKit
 class IntroViewController: UIViewController {
 
     // MARK: Properties
+    var interviewModelController:InterviewModelController!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        interviewModelController.generateScript()
+        
         // Do any additional setup after loading the view, typically from a nib.
     }
 

--- a/Arobotherapy/Controllers/IntroViewController.swift
+++ b/Arobotherapy/Controllers/IntroViewController.swift
@@ -19,7 +19,12 @@ class IntroViewController: UIViewController, InterviewProtocol {
         
         // Do any additional setup after loading the view, typically from a nib.
     }
-
-    // MARK: Actions
+    
+    // MARK: Navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
+            interviewProtocolViewController.interviewModelController = interviewModelController
+        }
+    }
 }
 

--- a/Arobotherapy/Controllers/IntroViewController.swift
+++ b/Arobotherapy/Controllers/IntroViewController.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-class IntroViewController: UIViewController {
+class IntroViewController: UIViewController, InterviewProtocol {
 
     // MARK: Properties
-    var interviewModelController:InterviewModelController!
+    var interviewModelController:InterviewModelController = InterviewModelController()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Arobotherapy/Controllers/PassageInstructionViewController.swift
+++ b/Arobotherapy/Controllers/PassageInstructionViewController.swift
@@ -19,15 +19,11 @@ class PassageInstructionViewController: UIViewController, InterviewProtocol {
         // Do any additional setup after loading the view.
     }
     
-
-    /*
     // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
+            interviewProtocolViewController.interviewModelController = interviewModelController
+        }
     }
-    */
-
+    
 }

--- a/Arobotherapy/Controllers/PassageInstructionViewController.swift
+++ b/Arobotherapy/Controllers/PassageInstructionViewController.swift
@@ -8,7 +8,10 @@
 
 import UIKit
 
-class PassageInstructionViewController: UIViewController {
+class PassageInstructionViewController: UIViewController, InterviewProtocol {
+    
+    // MARK: Properties
+    var interviewModelController:InterviewModelController = InterviewModelController()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Arobotherapy/Controllers/PassageRecordingViewController.swift
+++ b/Arobotherapy/Controllers/PassageRecordingViewController.swift
@@ -8,25 +8,24 @@
 
 import UIKit
 
-class PassageRecordingViewController: UIViewController {
-    @IBOutlet weak var passageTextView: UITextView!
+class PassageRecordingViewController: UIViewController, InterviewProtocol {
+    var interviewModelController:InterviewModelController = InterviewModelController()
     
-    // MARK: - Properties
+    // MARK: Properties
+    @IBOutlet weak var passageTextView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        print(interviewModelController.chosenPassage)
+        print(interviewModelController.chosenPassage!.text)
+        passageTextView.text = interviewModelController.chosenPassage!.text
     }
     
-
-    /*
     // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
+            interviewProtocolViewController.interviewModelController = interviewModelController
+        }
     }
-    */
 
 }

--- a/Arobotherapy/Controllers/ThankYouViewController.swift
+++ b/Arobotherapy/Controllers/ThankYouViewController.swift
@@ -20,14 +20,11 @@ class ThankYouViewController: UIViewController, InterviewProtocol {
     }
     
 
-    /*
     // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
+            interviewProtocolViewController.interviewModelController = interviewModelController
+        }
     }
-    */
 
 }

--- a/Arobotherapy/Controllers/ThankYouViewController.swift
+++ b/Arobotherapy/Controllers/ThankYouViewController.swift
@@ -8,7 +8,10 @@
 
 import UIKit
 
-class ThankYouViewController: UIViewController {
+class ThankYouViewController: UIViewController, InterviewProtocol {
+
+    // MARK: Properties
+    var interviewModelController:InterviewModelController = InterviewModelController()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Arobotherapy/Protocols/InterviewProtocol.swift
+++ b/Arobotherapy/Protocols/InterviewProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  InterviewProtocol.swift
+//  Arobotherapy
+//
+//  Created by Dan Schultz on 10/17/18.
+//  Copyright © 2018 Bad Idea Factory. All rights reserved.
+//
+
+import Foundation
+
+protocol InterviewProtocol {
+    var interviewModelController:InterviewModelController { get set }
+}


### PR DESCRIPTION
The automated interview prompts the subject to read a passage out loud (to be recorded, eventually).  That passage is randomly selected from a list of predefined passages.  They were being loaded, but not being rendered.  This PR changes that, resulting in a passage randomly being selected right after the application starts.

The reason the script is generated on the intro view is that, eventually, we will have the flow go back to the intro screen upon conclusion of an interview.  We want a new interview script to be generated each time, and so that intro view is the right time to do it.

This PR resolves #13 and also makes some progress towards #14 