### PR TITLE
Render questions

### DIFF
--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -257,6 +257,9 @@
                                                     <constraint firstAttribute="height" constant="75" id="EgC-Ph-hzJ"/>
                                                 </constraints>
                                                 <state key="normal" title="Next"/>
+                                                <connections>
+                                                    <action selector="nextButtonPressed:" destination="80G-05-Yhh" eventType="touchUpInside" id="wVM-0o-MEP"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <constraints>
@@ -278,6 +281,12 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="9B4-bu-2RT"/>
                     </view>
+                    <connections>
+                        <outlet property="interviewBackButton" destination="VuY-hr-vNN" id="TVi-iq-ooI"/>
+                        <outlet property="interviewNextButton" destination="AQq-cG-aR9" id="dI1-Bt-YJb"/>
+                        <outlet property="interviewTextLabel" destination="Pem-vE-zmJ" id="4CP-xn-M3t"/>
+                        <segue destination="prb-9B-auF" kind="show" identifier="interviewFinishedSegue" id="yp3-9C-Sno"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="m1N-v0-27J" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -250,6 +250,9 @@
                                                     <constraint firstAttribute="height" constant="75" id="mcH-1u-ueS"/>
                                                 </constraints>
                                                 <state key="normal" title="Back"/>
+                                                <connections>
+                                                    <action selector="backButtonPressed:" destination="80G-05-Yhh" eventType="touchUpInside" id="IYi-YX-OhI"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AQq-cG-aR9">
                                                 <rect key="frame" x="177.5" y="0.0" width="177.5" height="75"/>
@@ -286,6 +289,7 @@
                         <outlet property="interviewNextButton" destination="AQq-cG-aR9" id="dI1-Bt-YJb"/>
                         <outlet property="interviewTextLabel" destination="Pem-vE-zmJ" id="4CP-xn-M3t"/>
                         <segue destination="prb-9B-auF" kind="show" identifier="interviewFinishedSegue" id="yp3-9C-Sno"/>
+                        <segue destination="gCW-eq-IHe" kind="show" identifier="interviewBackSegue" id="upo-gN-M5d"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="m1N-v0-27J" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -329,6 +333,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
+        <segue reference="upo-gN-M5d"/>
         <segue reference="RsO-4E-KMJ"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Arobotherapy/Controllers/InterviewViewController.swift
+++ b/Arobotherapy/Controllers/InterviewViewController.swift
@@ -12,11 +12,23 @@ class InterviewViewController: UIViewController, InterviewProtocol {
 
     // MARK: Properties
     var interviewModelController:InterviewModelController = InterviewModelController()
+    var currentQuestionIndex = 0
+    @IBOutlet weak var interviewBackButton: UIButton!
+    @IBOutlet weak var interviewNextButton: UIButton!
+    @IBOutlet weak var interviewTextLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        currentQuestionIndex = 0
+        renderNextQuestion()
+    }
+    // MARK: - Actions
+    @IBAction func nextButtonPressed(_ sender: Any) {
+        if(isInterviewFinished()) {
+            triggerNextSegue()
+        } else {
+            renderNextQuestion()
+        }
     }
     
     // MARK: - Navigation
@@ -24,6 +36,32 @@ class InterviewViewController: UIViewController, InterviewProtocol {
         if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
             interviewProtocolViewController.interviewModelController = interviewModelController
         }
+    }
+    
+    func renderNextQuestion() {
+        if(interviewModelController.chosenQuestions.count <= currentQuestionIndex) {
+            return triggerNextSegue()
+        }
+        let nextQuestion = interviewModelController.chosenQuestions[currentQuestionIndex]
+        interviewTextLabel.text = nextQuestion.text
+        currentQuestionIndex += 1
+    }
+    
+    func renderPreviousQuestion() {
+        currentQuestionIndex -= 1
+        if(interviewModelController.chosenQuestions.count <= currentQuestionIndex) {
+            return triggerNextSegue()
+        }
+        let nextQuestion = interviewModelController.chosenQuestions[currentQuestionIndex]
+        interviewTextLabel.text = nextQuestion.text
+    }
+    
+    func triggerNextSegue() {
+        performSegue(withIdentifier: "interviewFinishedSegue", sender: interviewNextButton)
+    }
+    
+    func isInterviewFinished() -> Bool {
+        return false
     }
 
 }

--- a/Arobotherapy/Controllers/InterviewViewController.swift
+++ b/Arobotherapy/Controllers/InterviewViewController.swift
@@ -19,7 +19,7 @@ class InterviewViewController: UIViewController, InterviewProtocol {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        currentQuestionIndex = 0
+        currentQuestionIndex = -1
         renderNextQuestion()
     }
     // MARK: - Actions
@@ -31,6 +31,10 @@ class InterviewViewController: UIViewController, InterviewProtocol {
         }
     }
     
+    @IBAction func backButtonPressed(_ sender: Any) {
+        renderPreviousQuestion()
+    }
+    
     // MARK: - Navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if var interviewProtocolViewController = segue.destination as? InterviewProtocol {
@@ -39,18 +43,18 @@ class InterviewViewController: UIViewController, InterviewProtocol {
     }
     
     func renderNextQuestion() {
-        if(interviewModelController.chosenQuestions.count <= currentQuestionIndex) {
+        currentQuestionIndex += 1
+        if(currentQuestionIndex >= interviewModelController.chosenQuestions.count) {
             return triggerNextSegue()
         }
         let nextQuestion = interviewModelController.chosenQuestions[currentQuestionIndex]
         interviewTextLabel.text = nextQuestion.text
-        currentQuestionIndex += 1
     }
     
     func renderPreviousQuestion() {
         currentQuestionIndex -= 1
-        if(interviewModelController.chosenQuestions.count <= currentQuestionIndex) {
-            return triggerNextSegue()
+        if(currentQuestionIndex < 0) {
+            return triggerBackSegue()
         }
         let nextQuestion = interviewModelController.chosenQuestions[currentQuestionIndex]
         interviewTextLabel.text = nextQuestion.text
@@ -58,6 +62,10 @@ class InterviewViewController: UIViewController, InterviewProtocol {
     
     func triggerNextSegue() {
         performSegue(withIdentifier: "interviewFinishedSegue", sender: interviewNextButton)
+    }
+    
+    func triggerBackSegue() {
+        performSegue(withIdentifier: "interviewBackSegue", sender: interviewNextButton)
     }
     
     func isInterviewFinished() -> Bool {


### PR DESCRIPTION
If a question script is determined, and nobody is there to render them, did it even happen?

This PR resolves that philosophical quandary by enabling the actual presentation of questions to the user.  The next / back buttons on the interview interface are also kicked into gear and work properly.  With this PR the most basic functionality of the entire user experience is complete.  You can click the next button and go interview after interview after interview.

This does not handle actually playing the question audio (or recording answers), but I do believe that it is enough to say we've resolved #13 and resolved #7 