### PR TITLE
Track time recorded

### DIFF
--- a/Arobotherapy/Controllers/InterviewViewController.swift
+++ b/Arobotherapy/Controllers/InterviewViewController.swift
@@ -92,7 +92,13 @@ class InterviewViewController: UIViewController, InterviewProtocol {
     func renderQuestion(question: Question) {
         interviewTextLabel.text = question.text
         interviewModelController.recordingModelController.prepareQuestionRecording(index: currentQuestionIndex)
-        playQuestionAudio(question: question)
+        
+        // TODO: This 300 second timer should be configurable
+        if(interviewModelController.recordingModelController.qualityTime < 300) {
+            playQuestionAudio(question: question)
+        } else {
+            triggerNextSegue()
+        }
     }
     
     func triggerNextSegue() {

--- a/Arobotherapy/Controllers/RecordingModelController.swift
+++ b/Arobotherapy/Controllers/RecordingModelController.swift
@@ -21,8 +21,10 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
     private var version = 0
     private var currentFilename = ""
     
+    var qualityTime = 0
     var recordedQuestions = [[String]]()
     var recordedPassages = [String]()
+    var longestAnswers = [Int]()
     
     func preparePassageRecording() {
         let timestamp = Int(Date().timeIntervalSince1970)
@@ -30,10 +32,24 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
         setupRecorder()
     }
     func prepareQuestionRecording(index: Int) {
+        logTime(time: Int(audioRecorder.currentTime), index: index)
+        
         let timestamp = Int(Date().timeIntervalSince1970)
         questionIndex = index
         currentFilename = participantId + "_" + String(timestamp) + "_question" + String(questionIndex) + "_" + String(recordedPassages.count)
         setupRecorder()
+    }
+    
+    private func logTime(time: Int, index: Int) {
+        if(!longestAnswers.indices.contains(questionIndex)) {
+            longestAnswers.insert(0, at: questionIndex)
+        }
+        longestAnswers[questionIndex] = max(time, longestAnswers[questionIndex])
+        recalculateQualityTime()
+    }
+    
+    private func recalculateQualityTime() {
+        qualityTime = longestAnswers.reduce(0, +)
     }
 
     func checkRecordPermission() {
@@ -64,7 +80,6 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
         self.currentFilename = filename
         
         if audioRecorder != nil {
-            stopRecording()
             setupRecorder()
         }
     }


### PR DESCRIPTION
The logic for this system is that each question will contribute a total
of MAX(answers(i)) seconds to the total recorded time.  For instance, if
the user answers the same question two times, one for 30 seconds one for
60 seconds, then it would only contribute the 60 second time to the
total.

In addition to this logic, we have inserted the "stop asking questions
after five minutes of quality answers" logic.

Resolves #31