### PR TITLE
Store versions of recordings

### DIFF
--- a/Arobotherapy/Controllers/InterviewModelController.swift
+++ b/Arobotherapy/Controllers/InterviewModelController.swift
@@ -15,7 +15,7 @@ class InterviewModelController {
     var chosenPassage:Passage?
     var chosenQuestions: [Question] = []
     
-    var recordingModelController = RecordingModelController()
+    var recordingModelController: RecordingModelController = RecordingModelController()
     
     func generateScript() {
         loadData()
@@ -41,6 +41,7 @@ class InterviewModelController {
                 mayHaveMore = true
             }
         }
+        recordingModelController.setInterviewModelController(interviewModel: self)
     }
     
     func loadData() {

--- a/Arobotherapy/Controllers/InterviewViewController.swift
+++ b/Arobotherapy/Controllers/InterviewViewController.swift
@@ -75,6 +75,7 @@ class InterviewViewController: UIViewController, InterviewProtocol {
 
     func repeatCurrentQuestion() {
         let currentQuestion = interviewModelController.chosenQuestions[currentQuestionIndex]
+        interviewModelController.recordingModelController.prepareQuestionRecording(index: currentQuestionIndex)
         playQuestionAudio(question: currentQuestion)
     }
 
@@ -90,11 +91,11 @@ class InterviewViewController: UIViewController, InterviewProtocol {
     }
     
     func renderQuestion(question: Question) {
-        interviewTextLabel.text = question.text
         interviewModelController.recordingModelController.prepareQuestionRecording(index: currentQuestionIndex)
         
         // TODO: This 300 second timer should be configurable
         if(interviewModelController.recordingModelController.qualityTime < 300) {
+            interviewTextLabel.text = question.text
             playQuestionAudio(question: question)
         } else {
             triggerNextSegue()

--- a/Arobotherapy/Controllers/RecordingModelController.swift
+++ b/Arobotherapy/Controllers/RecordingModelController.swift
@@ -17,27 +17,53 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
     private var recordPermission = false
     
     private var participantId: String = ""
-    private var questionIndex = 0
-    private var version = 0
-    private var currentFilename = ""
+    private var questionIndex: Int = 0
+    private var currentVersion: String = "0"
+    private var currentFilename: String = ""
+    
+    private var interviewModel: InterviewModelController?
     
     var qualityTime = 0
-    var recordedQuestions = [[String]]()
-    var recordedPassages = [String]()
+    var questionVersions = [Int]()
+    var passageVersion = 0
     var longestAnswers = [Int]()
     
+    func setInterviewModelController(interviewModel: InterviewModelController) {
+        self.interviewModel = interviewModel
+    }
+    
     func preparePassageRecording() {
-        let timestamp = Int(Date().timeIntervalSince1970)
-        currentFilename = participantId + "_" + String(timestamp) + "_passage_" + String(recordedPassages.count)
+        let timestamp: String = String(Int(Date().timeIntervalSince1970))
+        currentVersion = String(incrementPassageVersion())
+        let passageId: String = interviewModel!.chosenPassage!.id
+        currentFilename = participantId + "_passage-v" + currentVersion + "_" + passageId + "_" + timestamp
         setupRecorder()
     }
+    
     func prepareQuestionRecording(index: Int) {
         logTime(time: Int(audioRecorder.currentTime), index: index)
+        self.questionIndex = index
+
+        let timestamp: String = String(Int(Date().timeIntervalSince1970))
+        currentVersion = String(incrementQuestionVersion(index: index))
+        let questionId: String = interviewModel!.chosenQuestions[index].id
+        let questionIndex: String = String(index)
         
-        let timestamp = Int(Date().timeIntervalSince1970)
-        questionIndex = index
-        currentFilename = participantId + "_" + String(timestamp) + "_question" + String(questionIndex) + "_" + String(recordedPassages.count)
+        currentFilename = participantId + "_question-" + questionIndex + "-v" + currentVersion + "_" + questionId + "_" + timestamp
         setupRecorder()
+    }
+    
+    private func incrementQuestionVersion(index: Int) -> Int{
+        if(!questionVersions.indices.contains(index)) {
+            questionVersions.insert(0, at: index)
+        }
+        questionVersions[index] += 1
+        return questionVersions[index]
+    }
+    
+    private func incrementPassageVersion() -> Int{
+        passageVersion += 1
+        return passageVersion
     }
     
     private func logTime(time: Int, index: Int) {


### PR DESCRIPTION
This commit redefines the way recorded responses are stored, making it
possible to store more than one response to the same question while also
encoding the id of the passage / question as part of the filename.

Under this logic there are two patterns for filenames.

For passage recordings:
{participant ID}_passage-v{response version}_{passage ID}_{timestamp}.m4a

For question recordings:
{participant ID}_question-{index}-v{response version}_{question
ID}_{timestamp}.m4a

Where:

- Participant ID is the value entered by the interviewer before starting
the interview.
- Response Version is the "take" (so if they repeat a question / go back
to a past question, it would start a new recording with an incremented
version).
- Passage / Question ID is the filename of the passage / question that
was rendered to the user.
- Timestamp is the unix timestamp at the moment that the recording
began.

Issue #37 Correct logic for repeating questions