### PR TITLE
Enable files app integration

### DIFF
--- a/Arobotherapy/Info.plist
+++ b/Arobotherapy/Info.plist
@@ -17,13 +17,17 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This application records the responses to interview questions. The recordings are available to the iPad owner only, and are not uploaded by the application to any third party server.</string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
iOS 11 has a new "Files" application which can expose the files
associated with an app.  This should make it easier to export / manage
the recorded files, and to check things in closer to real time.

https://www.appcoda.com/files-app-integration/

Resolves #18