### PR TITLE
Fix recording

### DIFF
--- a/Arobotherapy/Controllers/InterviewViewController.swift
+++ b/Arobotherapy/Controllers/InterviewViewController.swift
@@ -28,8 +28,8 @@ class InterviewViewController: UIViewController, InterviewProtocol {
         interviewRepeatButton.layer.cornerRadius = 4
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         currentQuestionIndex = -1
         renderNextQuestion()
     }
@@ -69,7 +69,6 @@ class InterviewViewController: UIViewController, InterviewProtocol {
         }
         let nextQuestion = interviewModelController.chosenQuestions[currentQuestionIndex]
         renderQuestion(question: nextQuestion)
-
     }
     
     func renderPreviousQuestion() {

--- a/Arobotherapy/Controllers/RecordingModelController.swift
+++ b/Arobotherapy/Controllers/RecordingModelController.swift
@@ -49,7 +49,7 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
     }
     
     func prepareQuestionRecording(index: Int) {
-        logTime(time: Int(audioRecorder.currentTime), index: index)
+        logTime(time: Int(audioRecorder.currentTime), index: self.questionIndex)
         self.questionIndex = index
 
         let timestamp: String = String(Int(Date().timeIntervalSince1970))
@@ -76,10 +76,10 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
     
     private func logTime(time: Int, index: Int) {
         print(time)
-        if(!longestAnswers.indices.contains(questionIndex)) {
-            longestAnswers.insert(0, at: questionIndex)
+        if(!longestAnswers.indices.contains(index)) {
+            longestAnswers.insert(0, at: index)
         }
-        longestAnswers[questionIndex] = max(time, longestAnswers[questionIndex])
+        longestAnswers[index] = max(time, longestAnswers[index])
         recalculateQualityTime()
     }
     
@@ -127,32 +127,41 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
         checkRecordPermission()
         if recordPermission {
             do {
-                let audioSession = AVAudioSession.sharedInstance()
-                do {
-                    try audioSession.setCategory(
-                        AVAudioSession.Category.playAndRecord,
-                        mode: AVAudioSession.Mode.default)
-                } catch let error as NSError {
-                    print(error.description)
-                }
-                
                 let settings = [
                     AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
                     AVSampleRateKey: 44100,
                     AVNumberOfChannelsKey: 2,
                     AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
                 ]
+                
                 audioRecorder = try AVAudioRecorder(url: fileUrl(), settings: settings)
                 audioRecorder.delegate = self
                 audioRecorder.isMeteringEnabled = true
                 audioRecorder.prepareToRecord()
             }
-            catch {}
+            catch let error as NSError {
+                print(error.description)
+            }
+            
         }
     }
     
+    func ensureRecordingSession() {
+        
+    }
+    
     func startRecording() {
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(
+                AVAudioSession.Category.playAndRecord,
+                mode: AVAudioSession.Mode.default)
+        }
+        catch let error as NSError {
+            print(error.description)
+        }
         audioRecorder.record()
+        print(audioRecorder.isRecording)
     }
 
     func stopRecording() {

--- a/Arobotherapy/Controllers/RecordingModelController.swift
+++ b/Arobotherapy/Controllers/RecordingModelController.swift
@@ -75,6 +75,7 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
     }
     
     private func logTime(time: Int, index: Int) {
+        print(time)
         if(!longestAnswers.indices.contains(questionIndex)) {
             longestAnswers.insert(0, at: questionIndex)
         }
@@ -126,6 +127,15 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
         checkRecordPermission()
         if recordPermission {
             do {
+                let audioSession = AVAudioSession.sharedInstance()
+                do {
+                    try audioSession.setCategory(
+                        AVAudioSession.Category.playAndRecord,
+                        mode: AVAudioSession.Mode.default)
+                } catch let error as NSError {
+                    print(error.description)
+                }
+                
                 let settings = [
                     AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
                     AVSampleRateKey: 44100,

--- a/Arobotherapy/Info.plist
+++ b/Arobotherapy/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Recording was working on the simulator, but since the iPad is more likely to have an alternate AV setting, we needed to properly set the mode to RecordAndPlay before recording would start.

It is likely that we need to somehow insert that mode change in event handlers for when focus is regained to handle the situation where a user navigates away from the app and plays music (which I imagine would change the mode).  This is an edge case that is unlikely to manifest, but it is worth testing separately from his PR.

Resolves #41 