### PR TITLE
Revamp passage recording logic

### DIFF
--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -132,7 +132,6 @@
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="epl-7u-bb5">
                                         <rect key="frame" x="0.0" y="0.0" width="355" height="457"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                         <fontDescription key="fontDescription" type="system" pointSize="50"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
@@ -150,7 +149,7 @@
                                                     <color key="titleColor" red="0.98837751259999995" green="0.98947216149999995" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 </state>
                                                 <connections>
-                                                    <segue destination="XJp-3W-j68" kind="show" id="RsO-4E-KMJ"/>
+                                                    <action selector="backButtonPressed:" destination="QOC-dG-YDS" eventType="touchUpInside" id="zrR-Kc-U7I"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gyE-vR-H68">
@@ -164,7 +163,7 @@
                                                     <color key="titleColor" red="0.98837751259999995" green="0.98947216149999995" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 </state>
                                                 <connections>
-                                                    <segue destination="gCW-eq-IHe" kind="show" id="xfi-wx-gLz"/>
+                                                    <action selector="continueButtonPressed:" destination="QOC-dG-YDS" eventType="touchUpInside" id="EdR-gf-XOt"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -188,11 +187,13 @@
                         <outlet property="backButton" destination="iEY-vw-Mce" id="FBw-tY-ix4"/>
                         <outlet property="continueButton" destination="gyE-vR-H68" id="myi-kb-K4S"/>
                         <outlet property="passageTextView" destination="epl-7u-bb5" id="tl0-Pl-dXZ"/>
+                        <segue destination="gCW-eq-IHe" kind="show" identifier="passagesFinishedSegue" id="epe-vL-JNP"/>
+                        <segue destination="XJp-3W-j68" kind="show" identifier="passageBackSegue" id="adY-Yf-tlX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6Cc-eh-aiF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1372" y="132.68365817091455"/>
+            <point key="canvasLocation" x="1370" y="133"/>
         </scene>
         <!--Interview Instruction View Controller-->
         <scene sceneID="yET-FC-h0F">
@@ -339,7 +340,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="m1N-v0-27J" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2815" y="140"/>
+            <point key="canvasLocation" x="2839" y="133"/>
         </scene>
         <!--Thank You View Controller-->
         <scene sceneID="V3w-aU-ikw">
@@ -375,7 +376,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xvR-qg-dU9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3582" y="140"/>
+            <point key="canvasLocation" x="3583" y="133"/>
         </scene>
         <!--Participant Id View Controller-->
         <scene sceneID="TeZ-qB-AU1">
@@ -457,7 +458,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="upo-gN-M5d"/>
-        <segue reference="SiK-8a-usr"/>
+        <segue reference="epe-vL-JNP"/>
+        <segue reference="adY-Yf-tlX"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Arobotherapy/Controllers/InterviewModelController.swift
+++ b/Arobotherapy/Controllers/InterviewModelController.swift
@@ -12,18 +12,18 @@ class InterviewModelController {
     var passages: [Passage] = []
     var questionBlocks: [[Question]] = []
     
-    var chosenPassage:Passage?
+    var chosenPassages: [Passage] = []
     var chosenQuestions: [Question] = []
     
     var recordingModelController: RecordingModelController = RecordingModelController()
     
     func generateScript() {
         loadData()
-        
-        // Select exactly one passage
-        if(passages.count > 0) {
-            self.chosenPassage = passages.randomElement()!
-        }
+
+        // We want to use all passages
+        // TODO: In the past this was not the logic; if it changes again we should
+        // make passage selection process configurable
+        self.chosenPassages = passages
         
         // Iterate through the questions to generate the script
         var questionPool = questionBlocks

--- a/Arobotherapy/Controllers/PassageRecordingViewController.swift
+++ b/Arobotherapy/Controllers/PassageRecordingViewController.swift
@@ -12,23 +12,69 @@ class PassageRecordingViewController: UIViewController, InterviewProtocol {
     var interviewModelController:InterviewModelController = InterviewModelController()
     
     // MARK: Properties
+    var currentPassageIndex = 0
     @IBOutlet weak var passageTextView: UITextView!
-    
     @IBOutlet weak var backButton: UIButton!
-    
-    @IBOutlet weak var continueButton: UIButton!
+    @IBOutlet weak var continueButton: UIButton!    
     
     override func viewDidLoad() {
         super.viewDidLoad()
         backButton.layer.cornerRadius = 4
         continueButton.layer.cornerRadius = 4
-        passageTextView.text = interviewModelController.chosenPassage!.text
-        interviewModelController.recordingModelController.preparePassageRecording()
-        interviewModelController.recordingModelController.startRecording()
+        currentPassageIndex = -1
+        renderNextPassage()
+    }
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        passageTextView.setContentOffset(.zero, animated: true)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
         interviewModelController.recordingModelController.stopRecording()
+    }
+    
+    @IBAction func continueButtonPressed(_ sender: Any) {
+        renderNextPassage()
+    }
+    
+    @IBAction func backButtonPressed(_ sender: Any) {
+        renderPreviousPassage()
+    }
+    
+    func renderNextPassage() {
+        currentPassageIndex += 1
+        
+        if(currentPassageIndex >= interviewModelController.chosenPassages.count) {
+            return triggerNextSegue()
+        }
+        let nextPassage = interviewModelController.chosenPassages[currentPassageIndex]
+        renderPassage(passage: nextPassage)
+    }
+    
+    func renderPreviousPassage() {
+        currentPassageIndex -= 1
+        
+        if(currentPassageIndex < 0) {
+            return triggerBackSegue()
+        }
+        
+        let nextPassage = interviewModelController.chosenPassages[currentPassageIndex]
+        renderPassage(passage: nextPassage)
+    }
+    
+    func renderPassage(passage: Passage) {
+        interviewModelController.recordingModelController.preparePassageRecording(index: currentPassageIndex)
+        interviewModelController.recordingModelController.startRecording()
+        passageTextView.text = passage.text
+        passageTextView.setContentOffset(.zero, animated: true)
+    }
+    
+    func triggerNextSegue() {
+        performSegue(withIdentifier: "passagesFinishedSegue", sender: continueButton)
+    }
+    
+    func triggerBackSegue() {
+        performSegue(withIdentifier: "passageBackSegue", sender: backButton)
     }
     
     // MARK: - Navigation

--- a/Arobotherapy/Controllers/RecordingModelController.swift
+++ b/Arobotherapy/Controllers/RecordingModelController.swift
@@ -23,16 +23,18 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
     private var interviewModel: InterviewModelController?
     
     private var questionIndex: Int = 0
+    private var passageIndex: Int = 0
     var qualityTime = 0
     var questionVersions = [Int]()
-    var passageVersion = 0
+    var passageVersions = [Int]()
     var longestAnswers = [Int]()
     
     func resetInterview() {
+        passageIndex = 0
         questionIndex = 0
         qualityTime = 0
         questionVersions = [Int]()
-        passageVersion = 0
+        passageVersions = [Int]()
         longestAnswers = [Int]()
     }
     
@@ -40,11 +42,14 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
         self.interviewModel = interviewModel
     }
     
-    func preparePassageRecording() {
+    func preparePassageRecording(index: Int) {
+        self.passageIndex = index
+        
         let timestamp: String = String(Int(Date().timeIntervalSince1970))
-        currentVersion = String(incrementPassageVersion())
-        let passageId: String = interviewModel!.chosenPassage!.id
-        currentFilename = participantId + "_passage-v" + currentVersion + "_" + passageId + "_" + timestamp
+        currentVersion = String(incrementPassageVersion(index: index))
+        let passageId: String = interviewModel!.chosenPassages[index].id
+        let passageIndex: String = String(index)
+        currentFilename = participantId + "_passage-" + passageIndex + "-v" + currentVersion + "_" + passageId + "_" + timestamp
         setupRecorder()
     }
     
@@ -69,9 +74,12 @@ class RecordingModelController: NSObject, AVAudioRecorderDelegate {
         return questionVersions[index]
     }
     
-    private func incrementPassageVersion() -> Int{
-        passageVersion += 1
-        return passageVersion
+    private func incrementPassageVersion(index: Int) -> Int{
+        if(!passageVersions.indices.contains(index)) {
+            passageVersions.insert(0, at: index)
+        }
+        passageVersions[index] += 1
+        return passageVersions[index]
     }
     
     private func logTime(time: Int, index: Int) {


### PR DESCRIPTION
In the previous interview flow, a random passage was selected for
reading for each participant.  This reflects a change in that logic, so
that now all possible passages are presented to the user for reading.

In order to support this we needed to update the passage recording
controller to function more like the interview controller.
Specifically, the next and back buttons now need to iterate through the
list of selected passages and only continue to the next view in the
event that you are in the beginning (or end) of the passage list.

This also meant that we needed to add support for multiple versions of
a given passage recording, as users could now go "back" to re-record
a given passage.

This implementation is also more flexible for future in the event that
the logic is updated again; even if only one passage is "selected" the
passage recording controller will function in the same way.

Resolves #45