### PR TITLE
Fix interview bug

### DIFF
--- a/Arobotherapy/Base.lproj/Main.storyboard
+++ b/Arobotherapy/Base.lproj/Main.storyboard
@@ -456,7 +456,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="upo-gN-M5d"/>
-        <segue reference="adY-Yf-tlX"/>
+        <segue reference="epe-vL-JNP"/>
+        <segue reference="SiK-8a-usr"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Arobotherapy/Controllers/InterviewModelController.swift
+++ b/Arobotherapy/Controllers/InterviewModelController.swift
@@ -19,6 +19,9 @@ class InterviewModelController {
     
     func generateScript() {
         loadData()
+        
+        // Clear out any previous script
+        self.chosenQuestions = []
 
         // We want to use all passages
         // TODO: In the past this was not the logic; if it changes again we should
@@ -43,7 +46,6 @@ class InterviewModelController {
         }
         recordingModelController.setInterviewModelController(interviewModel: self)
         recordingModelController.resetInterview()
-
     }
     
     func loadData() {
@@ -55,6 +57,8 @@ class InterviewModelController {
         if(passages.count != 0) {
             return
         }
+        // Just to be defensive, reset the passages
+        passages = []
 
         let path = Bundle.main.resourcePath! + "/Library/Passages"
         let items = getItemsInPath(path: path)
@@ -73,6 +77,9 @@ class InterviewModelController {
         if(!questionBlocks.isEmpty) {
             return
         }
+        // Just to be defensive, reset the question blocks
+        questionBlocks = []
+        
         // We need to initialize the zero index since it is a special case
         questionBlocks.append([])
         


### PR DESCRIPTION
There was a bug where interviews selections were not cleared for the second interview; this fixes that, and add some additional defensive steps just to make sure that only one copy of a given question is loaded.

Resolves #49